### PR TITLE
SQL - Table Schema - Nonce field - out of range error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+elaChain
 *.lock
 nohup.out
 sync
@@ -8,3 +10,4 @@ logs/*
 glide.lock
 go.mod
 go.sum
+*.backup

--- a/docs/sql/chain_chain_block_header.sql
+++ b/docs/sql/chain_chain_block_header.sql
@@ -30,7 +30,7 @@ CREATE TABLE `chain_block_header` (
   `version` int(2) NOT NULL,
   `merkleroot` varchar(64) COLLATE utf8mb4_bin NOT NULL COMMENT 'merkle root',
   `time` int(64) NOT NULL COMMENT 'block time',
-  `nonce` int(64) NOT NULL,
+  `nonce` BIGINT(64) NOT NULL,
   `bits` int(64) NOT NULL,
   `difficulty` varchar(64) COLLATE utf8mb4_bin NOT NULL,
   `chainwork` varchar(64) COLLATE utf8mb4_bin NOT NULL,

--- a/docs/sql/chain_chain_block_transaction_history.sql
+++ b/docs/sql/chain_chain_block_transaction_history.sql
@@ -52,5 +52,5 @@ CREATE TABLE `chain_block_transaction_history` (
 
 CREATE INDEX idx_chain_block_transaction_history_address ON chain_block_transaction_history (address);
 CREATE INDEX idx_chain_block_transaction_history_txid ON chain_block_transaction_history (txid);
+ALTER TABLE chain_block_transaction_history ADD txType VARCHAR(24) NOT NULL;
 CREATE INDEX idx_chain_block_transaction_history_txType_height ON chain_block_transaction_history (height,txType);
-alter table chain.chain_block_transaction_history add txType varchar(24) not null;

--- a/docs/sql/global_setting.sql
+++ b/docs/sql/global_setting.sql
@@ -1,1 +1,1 @@
-set global max_prepared_stmt_count=1 * 1024 * 1024;
+SET GLOBAL max_prepared_stmt_count=1 * 1024 * 1024;


### PR DESCRIPTION
```
2019/02/20 21:03:53.350020 [INFO] :Request URL = http://127.0.0.1:20604/api/v1/block/details/height/0 
2019/02/20 21:03:53.360573 [INFO] :Sync Height Error : Error 1264: Out of range value for column 'nonce' at row 1
```
"nonce":3194347904 is greater than INT, changed this to BIGINT.

Exactly how many bytes is the max size of nonce? This could probably be better as a VARCHAR too.

*Also fixed some ALTER TABLE stmt orders*
